### PR TITLE
Replace cal with newer ncal

### DIFF
--- a/src/mdlabbook.pl
+++ b/src/mdlabbook.pl
@@ -239,7 +239,7 @@ author: ".$opts->{author}."
 
       my ($y, $m) = ($month =~ /(20[0-9][0-9])([0-9][0-9])/) ;
 
-      my $calout = `cal $m $y` ; chomp $calout ;
+      my $calout = `ncal -bh $m $y` ; chomp $calout ;
       my @callines = split(/\n/, $calout) ;
       my $month_string = shift @callines ;
       $month_string =~ s/^ +// ;


### PR DESCRIPTION
The terminal highlight symbol broke the calendar generation, so that the current day would render wrongly, and not as a hyperlink. This PR switches from `cal` to `ncal` and turns the highlighting of the current day off.